### PR TITLE
fixed sgov dictionary parsing

### DIFF
--- a/tasks_params.yml
+++ b/tasks_params.yml
@@ -1,32 +1,43 @@
 sgov_kato:
-  url: https://stat.gov.kz/upload/iblock/d5e/zdybncxejbbg6e0gxwcw48kiwf5a251t/%D0%9A%D0%90%D0%A2%D0%9E_18.08.2023.xls
+  url: https://stat.gov.kz/ru/classifiers/statistical/21/
   skiptop: 1
   usecolumns: A:I
+  html_container_id: classifiers-199
+  format: xls
   ftp_directory: sgov
 
+
 sgov_oked:
-  url: https://stat.gov.kz/upload/iblock/7c4/avpvdw6e8ab31c77pgk1emb0mtnr2r1z.xlsx
+  url: https://stat.gov.kz/ru/classifiers/statistical/21/
   skiptop: 3
   usecolumns: A:C
+  html_container_id: classifiers-197
+  format: xlsx
   ftp_directory: sgov
 
 sgov_mkeis:
-  url: https://old.stat.gov.kz/api/getFile/?docId=ESTAT316776
-  skiptop: 4
+  url: https://stat.gov.kz/ru/classifiers/statistical/20/
+  skiptop: 13
   usecolumns: A:C
+  html_container_id: classifiers-194
+  format: xlsx
   ftp_directory: sgov
 
 sgov_kurk:
-  url: https://stat.gov.kz/upload/iblock/812/p6c51ws9i7hr02yyd2qllj934s96six2.rar
+  url: https://stat.gov.kz/ru/classifiers/statistical/23/
   skiptop: 16
   usecolumns: A:C
   skipbottom: 4
+  html_container_id: classifiers-218
+  format: rar
   ftp_directory: sgov
 
 sgov_kpved:
-  url: https://stat.gov.kz/upload/iblock/558/zpgw5k0pb4fg02jmtzqxd5saplm69vrm.xls
+  url: https://stat.gov.kz/ru/classifiers/statistical/21/
   skiptop: 3
   usecolumns: A:C
+  html_container_id: classifiers-198
+  format: xls
   ftp_directory: sgov
 
 kgd_bankrupt:


### PR DESCRIPTION
Now links are obtained through parsing the webpage of the directory website, rather than through a configuration file